### PR TITLE
Add optimizeForOpaque prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,16 @@ export default MyComponent;
 
 ## Props
 
-| Prop                | Type                | Default       | Description                                                                                                                                         |
-| ------------------- | ------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `source`            | ImageSourcePropType |               | The image source (either a remote URL or a local file resource)                                                                                     |
-| `duration`          | number              | `500`         | Duration of the fade transition in ms                                                                                                               |
-| `easing`            | EasingFunction      | `Easing.ease` | Easing function, see [available options](https://reactnative.dev/docs/easing)                                                                       |
-| `style`             | ViewStyle           |               | Style object applied to the wrapping View                                                                                                           |
-| `resizeMode`        | ImageResizeMode     | `cover`       | Image resize mode, see [available options](https://reactnative.dev/docs/image#resizemode)                                                           |
-| `optimizeForOpaque` | boolean             | `false`       | Fade the images simultaneously so the old picture disappears after the animation. At 50% of the transition time, both images will have 50% opacity. |
-| `blurRadius`        | number              |               | The blur radius of the blur filter applied to the image                                                                                             |
-| `children`          | ReactNode           |               | Any children provided will be shown on top of the image similar to `ImageBackground` component                                                      |
+| Prop          | Type                | Default       | Description                                                                                                                                         |
+| ------------- | ------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`      | ImageSourcePropType |               | The image source (either a remote URL or a local file resource)                                                                                     |
+| `duration`    | number              | `500`         | Duration of the fade transition in ms                                                                                                               |
+| `easing`      | EasingFunction      | `Easing.ease` | Easing function, see [available options](https://reactnative.dev/docs/easing)                                                                       |
+| `style`       | ViewStyle           |               | Style object applied to the wrapping View                                                                                                           |
+| `resizeMode`  | ImageResizeMode     | `cover`       | Image resize mode, see [available options](https://reactnative.dev/docs/image#resizemode)                                                           |
+| `reverseFade` | boolean             | `false`       | Fade the images simultaneously so the old picture disappears after the animation. At 50% of the transition time, both images will have 50% opacity. |
+| `blurRadius`  | number              |               | The blur radius of the blur filter applied to the image                                                                                             |
+| `children`    | ReactNode           |               | Any children provided will be shown on top of the image similar to `ImageBackground` component                                                      |
 
 ## Example app demo
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ React Native component for changing images with crossfade transition effect when
 ## Installation
 
 ### yarn
+
 ```sh
 yarn add react-native-crossfade-image
 ```
+
 ### npm
+
 ```sh
 npm install react-native-crossfade-image
 ```
@@ -78,15 +81,16 @@ export default MyComponent;
 
 ## Props
 
-Prop | Type | Default | Description
----|---|---|---
-`source` | ImageSourcePropType | | The image source (either a remote URL or a local file resource)
-`duration` | number | `500` | Duration of the fade transition in ms
-`easing` | EasingFunction | `Easing.ease` | Easing function, see [available options](https://reactnative.dev/docs/easing)
-`style`| ViewStyle | | Style object applied to the wrapping View
-`resizeMode` | ImageResizeMode | `cover` | Image resize mode, see [available options](https://reactnative.dev/docs/image#resizemode)
-`blurRadius` | number | | The blur radius of the blur filter applied to the image
-`children` | ReactNode | | Any children provided will be shown on top of the image similar to `ImageBackground` component
+| Prop                | Type                | Default       | Description                                                                                                                                         |
+| ------------------- | ------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`            | ImageSourcePropType |               | The image source (either a remote URL or a local file resource)                                                                                     |
+| `duration`          | number              | `500`         | Duration of the fade transition in ms                                                                                                               |
+| `easing`            | EasingFunction      | `Easing.ease` | Easing function, see [available options](https://reactnative.dev/docs/easing)                                                                       |
+| `style`             | ViewStyle           |               | Style object applied to the wrapping View                                                                                                           |
+| `resizeMode`        | ImageResizeMode     | `cover`       | Image resize mode, see [available options](https://reactnative.dev/docs/image#resizemode)                                                           |
+| `optimizeForOpaque` | boolean             | `false`       | Fade the images simultaneously so the old picture disappears after the animation. At 50% of the transition time, both images will have 50% opacity. |
+| `blurRadius`        | number              |               | The blur radius of the blur filter applied to the image                                                                                             |
+| `children`          | ReactNode           |               | Any children provided will be shown on top of the image similar to `ImageBackground` component                                                      |
 
 ## Example app demo
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ export interface CrossfadeImageProps extends ImageProps {
   duration?: number;
   easing?: EasingFunction;
   children?: React.ReactNode;
+  optimizeForOpaque?: boolean;
 }
 
 export const CrossfadeImage = ({
@@ -25,6 +26,7 @@ export const CrossfadeImage = ({
   duration = 500,
   easing = Easing.ease,
   children,
+  optimizeForOpaque = false,
   ...props
 }: CrossfadeImageProps) => {
   const prevSource = usePrevious(source);
@@ -32,6 +34,13 @@ export const CrossfadeImage = ({
   const opacity = useRef(new Animated.Value(0)).current;
   const [oldSource, setOldSource] = useState<ImageSourcePropType>(source);
   const [newSource, setNewSource] = useState<ImageSourcePropType>();
+
+  const inverseOpacity = optimizeForOpaque
+    ? opacity.interpolate({
+        inputRange: [0, 1],
+        outputRange: [1, 0],
+      })
+    : 1;
 
   useLayoutEffect(() => {
     if (prevSource && !isEqual(source, prevSource)) {
@@ -76,9 +85,9 @@ export const CrossfadeImage = ({
 
   return (
     <View style={[styles.root, style]}>
-      <Image
+      <Animated.Image
         {...props}
-        style={styles.image}
+        style={[styles.image, { opacity: inverseOpacity }]}
         source={oldSource}
         fadeDuration={0}
         onLoad={handleUpdate}
@@ -86,7 +95,7 @@ export const CrossfadeImage = ({
       {newSource && (
         <Animated.Image
           {...props}
-          style={[styles.image, { opacity }]}
+          style={[styles.image, { opacity: opacity }]}
           source={newSource}
           fadeDuration={0}
           onLoad={handleLoad}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,7 @@ export interface CrossfadeImageProps extends ImageProps {
   duration?: number;
   easing?: EasingFunction;
   children?: React.ReactNode;
-  optimizeForOpaque?: boolean;
+  reverseFade?: boolean;
 }
 
 export const CrossfadeImage = ({
@@ -26,7 +26,7 @@ export const CrossfadeImage = ({
   duration = 500,
   easing = Easing.ease,
   children,
-  optimizeForOpaque = false,
+  reverseFade = false,
   ...props
 }: CrossfadeImageProps) => {
   const prevSource = usePrevious(source);
@@ -35,7 +35,7 @@ export const CrossfadeImage = ({
   const [oldSource, setOldSource] = useState<ImageSourcePropType>(source);
   const [newSource, setNewSource] = useState<ImageSourcePropType>();
 
-  const inverseOpacity = optimizeForOpaque
+  const inverseOpacity = reverseFade
     ? opacity.interpolate({
         inputRange: [0, 1],
         outputRange: [1, 0],


### PR DESCRIPTION
I had a problem building an app, where i needed to fade a lot of **pictures with opaque elements** in them. This caused an unwanted stacking of images, so i quickly added this feature to overcome this issue. It now **interpolates the opacity value** between the 2 images and the former displayed image will completely fade out.

Thought it might be useful to someone else having the same issue :)